### PR TITLE
Make the onBefore() method and $config property protected

### DIFF
--- a/src/Oauth1.php
+++ b/src/Oauth1.php
@@ -33,7 +33,7 @@ class Oauth1
     const SIGNATURE_METHOD_PLAINTEXT = 'PLAINTEXT';
 
     /** @var array Configuration settings */
-    private $config;
+    protected $config;
 
     /**
      * Create a new OAuth 1.0 plugin.
@@ -91,7 +91,14 @@ class Oauth1
         };
     }
 
-    private function onBefore(RequestInterface $request)
+    /**
+     * Modifies the request to add OAuth headers or querystring parameters.
+     *
+     * @param RequestInterface $request Request to authenticate.
+     *
+     * @return RequestInterface
+     */
+    protected function onBefore(RequestInterface $request)
     {
         $oauthparams = $this->getOauthParams(
             $this->generateNonce($request),


### PR DESCRIPTION
I am dealing with authentication against a third-party service that slightly deviates from the OAuth spec and requires a tweak of the signature base string.

In the rare situations like this where it's necessary to extend the Oauth1 class, this would be made far simpler by changing the `Oauth1::onBefore` method and `Oauth1::$config` property to be protected instead of private.